### PR TITLE
Line height and logo tweaks

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -2,8 +2,11 @@ html {
   font-family: sans-serif;
   max-width: 45em;
   margin: 1em;
-  line-height: 1.4em;
   background-color: beige;
+}
+
+p {
+  line-height:1.4em;
 }
 
 h2 {
@@ -22,12 +25,12 @@ td {
   vertical-align: baseline;
 }
 
-#logo {
+h1#logo {
   font-family: serif;
   font-style: italic;
   font-size: 5em;
-  margin-top: 0.5em;
-  line-height: 1em;
+  margin-top: 0.3em;
+  margin-bottom: 0.3em;
 }
 
 a:link {


### PR DESCRIPTION
- Remove line height from `html`, specify in `p`
- Clarify #logo as h1#logo
- Adjust logo margins

Here are screenshots of what the new style looks like for the main title, and the previously problematic longer  title:

![2020-12-30_12:59:14](https://user-images.githubusercontent.com/9020453/103371990-d98b3800-4a9e-11eb-91dd-8e938f0086b6.png)


![2020-12-30_12:57:17](https://user-images.githubusercontent.com/9020453/103371928-a8ab0300-4a9e-11eb-8771-4470f8007510.png)

Here's what the latter looked like before;

![2020-12-30_13:01:53](https://user-images.githubusercontent.com/9020453/103372135-371f8480-4a9f-11eb-8629-35d84af6d3d1.png)
