### PR TITLE
Add groups.scheme.org

### DIFF
--- a/dns.zone
+++ b/dns.zone
@@ -32,6 +32,8 @@ lists IN CNAME alpha.servers
 
 wiki IN CNAME alpha.servers
 
+groups IN CNAME alpha.servers
+
 learn IN CNAME alpha.servers
 
 apps IN CNAME alpha.servers

--- a/projects.scm
+++ b/projects.scm
@@ -108,6 +108,14 @@
     (contacts "lassi" "arthur")
     (display? #t)
     (dns (rec (type "CNAME")
+              (data "alpha.servers"))))
+
+   ((project-id "groups")
+    (title "Groups")
+    (tagline "Work groups")
+    (contacts "lassi")
+    (display? #t)
+    (dns (rec (type "CNAME")
               (data "alpha.servers")))))
 
   ("Topics"


### PR DESCRIPTION
It's been a couple of weeks and no one has voiced a clear objection on the mailing list, so I'd like to experiment with a groups subdomain for low effort static content. We can remove it if it turns out that the idea sucks.