### PR TITLE
Add go.scheme.org

### DIFF
--- a/dns.zone
+++ b/dns.zone
@@ -10,7 +10,7 @@ www IN CNAME alpha.servers
 
 try IN CNAME alpha.servers
 
-faq IN CNAME redirect
+faq IN CNAME go
 
 cookbook IN CNAME alpha.servers
 
@@ -30,7 +30,7 @@ video IN CNAME alpha.servers
 
 lists IN CNAME alpha.servers
 
-wiki IN CNAME redirect
+wiki IN CNAME go
 
 groups IN CNAME alpha.servers
 
@@ -46,49 +46,49 @@ test IN CNAME alpha.servers
 
 web IN CNAME alpha.servers
 
-r5rs IN CNAME redirect
+r5rs IN CNAME go
 
-r6rs IN CNAME redirect
+r6rs IN CNAME go
 
-r7rs IN CNAME redirect
+r7rs IN CNAME go
 
 get IN CNAME alpha.servers
 
-bigloo IN CNAME redirect
+bigloo IN CNAME go
 
-chez IN CNAME redirect
+chez IN CNAME go
 
-chibi IN CNAME redirect
+chibi IN CNAME go
 
-chicken IN CNAME redirect
+chicken IN CNAME go
 
-cyclone IN CNAME redirect
+cyclone IN CNAME go
 
 gambit IN CNAME gambitscheme.org.
 
-gauche IN CNAME redirect
+gauche IN CNAME go
 
 gerbil IN CNAME cons.io.
 
-jazz IN CNAME redirect
+jazz IN CNAME go
 
-kawa IN CNAME redirect
+kawa IN CNAME go
 
 loko IN CNAME scheme.fail.
 
-mit IN CNAME redirect
+mit IN CNAME go
 
-mosh IN CNAME redirect
+mosh IN CNAME go
 
-s7 IN CNAME redirect
+s7 IN CNAME go
 
-sagittarius IN CNAME redirect
+sagittarius IN CNAME go
 
-scm IN CNAME redirect
+scm IN CNAME go
 
-stklos IN CNAME redirect
+stklos IN CNAME go
 
-ypsilon IN CNAME redirect
+ypsilon IN CNAME go
 
 conservatory IN CNAME alpha.servers
 
@@ -105,6 +105,8 @@ man IN CNAME alpha.servers
 files IN CNAME alpha.servers
 
 gitea IN CNAME alpha.servers
+
+go IN CNAME alpha.servers
 
 registry IN CNAME alpha.servers
 
@@ -127,5 +129,3 @@ play IN CNAME try
 doc IN CNAME docs
 
 list IN CNAME lists
-
-redirect IN CNAME alpha.servers

--- a/projects.scm
+++ b/projects.scm
@@ -25,7 +25,7 @@
     (contacts "lassi")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "cookbook")
     (title "Cookbook")
@@ -108,7 +108,7 @@
     (contacts "lassi" "arthur")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "groups")
     (title "Groups")
@@ -180,7 +180,7 @@
     (contacts "lassi")
     (display? #f)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "r6rs")
     (title "R^6RS")
@@ -188,7 +188,7 @@
     (contacts "lassi")
     (display? #f)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "r7rs")
     (title "R^7RS")
@@ -196,7 +196,7 @@
     (contacts "lassi")
     (display? #f)
     (dns (rec (type "CNAME")
-              (data "redirect")))))
+              (data "go")))))
 
   ("Implementations"
 
@@ -216,7 +216,7 @@
     (contacts "Manuel Serrano")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "chez")
     (title "Chez Scheme")
@@ -226,7 +226,7 @@
               "Andy Keep")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "chibi")
     (title "Chibi-Scheme")
@@ -235,7 +235,7 @@
     (contacts "Alex Shinn")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "chicken")
     (title "CHICKEN")
@@ -244,7 +244,7 @@
     (contacts "Mario Domenech Goulart" "chicken-meisters at nongnu.org")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "cyclone")
     (title "Cyclone")
@@ -253,7 +253,7 @@
     (contacts "Justin Ethier")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "gambit")
     (title "Gambit")
@@ -271,7 +271,7 @@
     (contacts "shirok")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "gerbil")
     (title "Gerbil")
@@ -289,7 +289,7 @@
     (contacts "Guillaume Cartier")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "kawa")
     (title "Kawa")
@@ -298,7 +298,7 @@
     (contacts "Per Bothner")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "loko")
     (title "Loko")
@@ -316,7 +316,7 @@
     (contacts "arthur")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "mosh")
     (title "Mosh")
@@ -325,7 +325,7 @@
     (contacts "Taro Minowa")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "s7")
     (title "s7")
@@ -334,7 +334,7 @@
     (contacts "bil" "lassi")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "sagittarius")
     (title "Sagittarius")
@@ -343,7 +343,7 @@
     (contacts "Takashi Kato")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "scm")
     (title "SCM")
@@ -352,7 +352,7 @@
     (contacts "Aubrey Jaffer" "lassi")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "stklos")
     (title "STklos")
@@ -361,7 +361,7 @@
     (contacts "Erick Gallesio")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "ypsilon")
     (title "Ypsilon")
@@ -371,7 +371,7 @@
               "Yoshikatsu Fujita")
     (display? #t)
     (dns (rec (type "CNAME")
-              (data "redirect"))))
+              (data "go"))))
 
    ((project-id "conservatory")
     (title "Conservatory")
@@ -437,6 +437,14 @@
     (title "Gitea")
     (tagline "Host Git repositories under Scheme.org")
     (contacts "lassi")
+    (display? #t)
+    (dns (rec (type "CNAME")
+              (data "alpha.servers"))))
+
+   ((project-id "go")
+    (title "Go Scheme")
+    (tagline "URL shortening service")
+    (contacts "lassi" "Jakub T. Jankiewicz")
     (display? #t)
     (dns (rec (type "CNAME")
               (data "alpha.servers"))))
@@ -515,13 +523,7 @@
     (contacts "arthur" "lassi")
     (display? #f)
     (dns (rec (type "CNAME")
-              (data "lists"))))
-
-   ((project-id "redirect")
-    (contacts "lassi" "arthur")
-    (display? #f)
-    (dns (rec (type "CNAME")
-              (data "alpha.servers"))))))
+              (data "lists"))))))
 
  (people
 


### PR DESCRIPTION
A user-visible URL shortening service. Agreed with Jakub on mailing
list just now. Also make it subsume the role of redirect.scheme.org.