### PR TITLE
Update description meta tag

### DIFF
--- a/www.scm
+++ b/www.scm
@@ -259,9 +259,10 @@
   (write-html-file
    html-filename
    "The Scheme Programming Language"
-   (string-append "Scheme is a minimalist dialect of the Lisp family "
-                  "of programming languages. This is the official website "
-                  "for the Scheme language.")
+   (string-append
+    "Comprehensive website for the Scheme programming language."
+    " Scheme is a dynamic functional language with macros."
+    " It is one of the main dialects of Lisp.")
    `(,(write-menu '(("Home" "https://scheme.org/" . active)
                     ("Docs" "https://docs.scheme.org/")
                     ("Community" "https://community.scheme.org/")


### PR DESCRIPTION
Since Scheme has no owner, no website has the moral authority to be
its official site. The closest thing to an official site would be one
that has the blessing of Sussman and Steele. I hope Scheme.org will
eventually be the most popular and comprehensive Scheme site.