### PR TITLE
Move most sites to tuonela

### DIFF
--- a/dns/scheme.org.zone
+++ b/dns/scheme.org.zone
@@ -6,7 +6,7 @@ $TTL 10800
 @ IN A 8.9.4.141
 @ IN AAAA 2001:19f0:5:6000:5400:2ff:fe07:9aa6
 
-www IN CNAME alpha.servers
+www IN CNAME @
 
 try IN CNAME tuonela
 
@@ -20,17 +20,17 @@ srfi IN CNAME srfi.schemers.org.
 
 research IN CNAME tuonela
 
-community IN CNAME alpha.servers
+community IN CNAME tuonela
 
 events IN CNAME tuonela
 
-planet IN CNAME alpha.servers
+planet IN CNAME tuonela
 
 video IN CNAME tuonela
 
 chat IN CNAME tuonela
 
-lists IN CNAME alpha.servers
+lists IN CNAME @
 
 wiki IN CNAME redirect
 
@@ -98,32 +98,29 @@ ypsilon IN CNAME redirect
 
 index IN CNAME ironwolf
 
-api IN CNAME alpha.servers
+api IN CNAME tuonela
 
 containers IN CNAME tuonela
 
-docs IN CNAME alpha.servers
+docs IN CNAME tuonela
 
 man IN CNAME tuonela
 
 conservatory IN CNAME tuonela
 
-files IN CNAME alpha.servers
+files IN CNAME @
 
 gitea IN CNAME tuonela
 
-go IN CNAME alpha.servers
+go IN CNAME tuonela
 
 registry IN CNAME tuonela
 
-servers IN CNAME alpha.servers
-alpha.servers IN CNAME @
-
 staging IN CNAME www.staging
-api.staging IN CNAME alpha.servers
-docs.staging IN CNAME alpha.servers
+api.staging IN CNAME tuonela
+docs.staging IN CNAME tuonela
 wiki.staging IN CNAME tuonela
-www.staging IN CNAME alpha.servers
+www.staging IN CNAME @
 
 ironwolf IN A 89.40.10.46
 ironwolf IN AAAA 2a02:7b40:5928:a2e::1

--- a/doc/charter.md
+++ b/doc/charter.md
@@ -50,9 +50,6 @@
 `staging` (subdomain `staging.scheme.org`): Staging versions of
 production projects.
 
-`servers` (subdomain `servers.scheme.org`): Server pool for Scheme
-projects.
-
 ## Email
 
 The following standard `@scheme.org` email addresses:

--- a/projects.scm
+++ b/projects.scm
@@ -6,7 +6,7 @@
     (comments "The www.scheme.org front page")
     (contacts "Arthur" "Lassi")
     (display? #f)
-    (dns (CNAME "alpha.servers"))))
+    (dns (CNAME "@"))))
 
   ("Language"
 
@@ -61,7 +61,7 @@
     (tagline "Scheme gathering spots around the internet")
     (contacts "Lassi" "Arthur" "Jakub T. Jankiewicz")
     (display? #t)
-    (dns (CNAME "alpha.servers")))
+    (dns (CNAME "tuonela")))
 
    ((project-id "events")
     (title "Events")
@@ -75,7 +75,7 @@
     (tagline "Blog posts from every corner of the Scheme community")
     (contacts "Lassi" "Arthur")
     (display? #t)
-    (dns (CNAME "alpha.servers")))
+    (dns (CNAME "tuonela")))
 
    ((project-id "video")
     (title "Video")
@@ -98,7 +98,7 @@
     (tagline "Mailing lists for email discussion of many Scheme topics")
     (contacts "Arthur")
     (display? #t)
-    (dns (CNAME "alpha.servers")))
+    (dns (CNAME "@")))
 
    ((project-id "wiki")
     (title "Wiki")
@@ -396,7 +396,7 @@
     (tagline "Programmable queries for all things Scheme")
     (contacts "Lassi")
     (display? #f)
-    (dns (CNAME "alpha.servers")))
+    (dns (CNAME "tuonela")))
 
    ((project-id "containers")
     (title "Containers")
@@ -411,7 +411,7 @@
     (comments "Discussed on the schemedoc@srfi.schemers.org mailing list.")
     (contacts "Lassi" "Arthur")
     (display? #t)
-    (dns (CNAME "alpha.servers")))
+    (dns (CNAME "tuonela")))
 
    ((project-id "man")
     (title "Manual pages")
@@ -433,7 +433,7 @@
     (tagline "Archive of current and historical files")
     (contacts "Lassi")
     (display? #t)
-    (dns (CNAME "alpha.servers")))
+    (dns (CNAME "@")))
 
    ((project-id "gitea")
     (title "Gitea")
@@ -447,7 +447,7 @@
     (tagline "URL shortening service")
     (contacts "Lassi" "Jakub T. Jankiewicz")
     (display? #t)
-    (dns (CNAME "alpha.servers")))
+    (dns (CNAME "tuonela")))
 
    ((project-id "registry")
     (title "Registry")
@@ -456,13 +456,6 @@
     (display? #t)
     (dns (CNAME "tuonela")))
 
-   ((project-id "servers")
-    (title "Servers")
-    (tagline "Server pool for Scheme projects")
-    (contacts "Lassi")
-    (display? #t)
-    (dns (CNAME "alpha.servers")
-         ("alpha" CNAME "@")))
 
    ((project-id "staging")
     (title "Staging")
@@ -470,10 +463,10 @@
     (contacts "Lassi")
     (display? #f)
     (dns (CNAME "www.staging")
-         ("api" CNAME "alpha.servers")
-         ("docs" CNAME "alpha.servers")
+         ("api" CNAME "tuonela")
+         ("docs" CNAME "tuonela")
          ("wiki" CNAME "tuonela")
-         ("www" CNAME "alpha.servers"))))
+         ("www" CNAME "@"))))
 
   ("Servers"
 


### PR DESCRIPTION
With this commit, the server name alpha.servers.scheme.org is retired. This server is now just scheme.org. In our DNS records, we refer to it using the standard zone file syntax "@" which refers to the origin of the domain.

Since there are no servers remaining under *.servers.scheme.org, the whole subdomain servers.scheme.org is retired too.

To recap, our servers are now:

- scheme.org (the origin server)
- ironwolf.scheme.org
- tuonela.scheme.org

With this commit, all static sites are moved to tuonela except for the following:

- www
- www.staging
- redirect
- lists
- files

These stay on the origin server (nee alpha).

lists stays because it involves mailing lists, which we have a persistent TODO item to explore how to do.

files stays because tuonela doesn't (yet) have enough disk space to house the massive backlog of Scheme releases. It should move as soon as we acquire extra disk space.