### PR TITLE
Update schemeworkshop.org DNS zone

### DIFF
--- a/dns/schemeworkshop.org.zone
+++ b/dns/schemeworkshop.org.zone
@@ -3,8 +3,8 @@
 ; $ORIGIN schemeworkshop.org.
 $TTL 10800
 
-@ IN A 165.124.180.241
+@ IN A 192.210.181.186
 
 www IN CNAME @
 
-www.staging IN A 192.210.181.186
+www.staging IN A @


### PR DESCRIPTION
Point both the main domain and the staging version to tuonela.scheme.org. (Use an A record instead of a CNAME record for the root of the domain for standards compliance.)