### PR TITLE
Remove jenkins.staging.scheme.org

### DIFF
--- a/dns/scheme.org.zone
+++ b/dns/scheme.org.zone
@@ -127,7 +127,6 @@ www.staging IN CNAME @
 api.staging IN CNAME tuonela
 docs.staging IN CNAME tuonela
 get.staging IN CNAME tuonela
-jenkins.staging IN CNAME jenkins
 wiki.staging IN CNAME tuonela
 
 ironwolf IN A 89.40.10.46

--- a/projects.pose
+++ b/projects.pose
@@ -565,7 +565,6 @@
          ("api" CNAME "tuonela")
          ("docs" CNAME "tuonela")
          ("get" CNAME "tuonela")
-         ("jenkins" CNAME "jenkins")
          ("wiki" CNAME "tuonela"))))
 
   ("Servers"


### PR DESCRIPTION
The production copy of Jenkins is enough. A separate staging copy is superfluous for the time being.

Discussed with Retropikzel by email.