### PR TITLE
Move index.scheme.org to tuonela

### DIFF
--- a/dns/scheme.org.zone
+++ b/dns/scheme.org.zone
@@ -98,7 +98,7 @@ stklos IN CNAME redirect
 
 ypsilon IN CNAME redirect
 
-index IN CNAME ironwolf
+index IN CNAME tuonela
 
 api IN CNAME tuonela
 
@@ -129,9 +129,6 @@ docs.staging IN CNAME tuonela
 get.staging IN CNAME tuonela
 index.staging IN CNAME tuonela
 wiki.staging IN CNAME tuonela
-
-ironwolf IN A 89.40.10.46
-ironwolf IN AAAA 2a02:7b40:5928:a2e::1
 
 tuonela IN A 192.210.181.186
 

--- a/projects.pose
+++ b/projects.pose
@@ -448,7 +448,7 @@
     (contacts "Arvydas Silanskas")
     (display? true)
     (dynamic? true)
-    (dns (CNAME "ironwolf"))
+    (dns (CNAME "tuonela"))
     (source (host "github.com")
             (organization "schemeorg-community")
             (repository "index.scheme.org")))
@@ -569,12 +569,6 @@
          ("wiki" CNAME "tuonela"))))
 
   ("Servers"
-
-   ((project-id "ironwolf")
-    (contacts "Arvydas Silanskas")
-    (display? false)
-    (dns (A "89.40.10.46")
-         (AAAA "2a02:7b40:5928:a2e::1")))
 
    ((project-id "tuonela")
     (contacts "Lassi")


### PR DESCRIPTION
The server ironwolf.scheme.org did not host any sites other than index.scheme.org so the server is retired.