### PR TITLE
Change staging IP address

### DIFF
--- a/dns/scheme.org.zone
+++ b/dns/scheme.org.zone
@@ -123,7 +123,7 @@ jenkins IN A 49.13.140.103
 registry IN CNAME tuonela
 
 staging IN CNAME www.staging
-www.staging IN CNAME @
+www.staging IN A 64.176.208.18
 api.staging IN CNAME tuonela
 docs.staging IN CNAME tuonela
 get.staging IN CNAME tuonela

--- a/lib/sensible.scm
+++ b/lib/sensible.scm
@@ -71,7 +71,7 @@
      (host
       (name scheme)
       (vars
-       (var ansible-host "8.9.4.141")
+       (var ansible-host "64.176.208.18")
        (var ansible-python-interpreter "/usr/bin/python3"))))))
 
  `(playbooks

--- a/projects.pose
+++ b/projects.pose
@@ -561,7 +561,7 @@
     (contacts "Lassi")
     (display? false)
     (dns (CNAME "www.staging")
-         ("www" CNAME "@")
+         ("www" A "64.176.208.18")
          ("api" CNAME "tuonela")
          ("docs" CNAME "tuonela")
          ("get" CNAME "tuonela")


### PR DESCRIPTION
"Vultr will lose the ability to use all IPv4 addresses in the 8.x.x.x range currently in operation on our platform due to them being reclaimed by the provider."